### PR TITLE
Exclude null and undefined from Option()'s inferred type parameter

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -18,7 +18,7 @@ module monapt {
         None(): B;
     }
 
-    export var Option = <T>(value: T): Option<T> => {
+    export var Option = <T>(value: T | null | undefined): Option<T> => {
         if (typeof value !== "undefined" && value !== null) {
             return new Some(value);
         }


### PR DESCRIPTION
With strict null checks enabled, the current `Option()` constructor causes the `Option`'s inferred type to include `_ | null | undefined` if the argument was of such type. This is not intended, as the goal of `Option` is to map those two types to `None`, as is enforced by the constructor.

This patch ensures that `T` does not include such union types.

I've tried and failed to write a failing test to cover this change. By definition, it's not possible to assert on a parameterized type in JavaScript since generics are erased during the TypeScript compilation. I haven't found a pattern to do it in TypeScript either.

The closest I've found is a test like

``` typescript
it('extracts the type of the value, ignoring undefined', () => {
  var value = 'value' as string | undefined;
  var opt: monapt.Option<string> = monapt.Option(value);
  // ^ will cause tsc compilation to fail
});
```

run through `tsc --noEmit` for type checking. It will fail to compile, but only if strictNullChecks is enabled. However monapt currently has a number of existing errors when enabling strict null checks, so that'd need to be fixed first.