### PR TITLE
feat(future): add flatMapP function

### DIFF
--- a/src/future/future.ts
+++ b/src/future/future.ts
@@ -95,6 +95,28 @@ class Future<A> {
     );
   }
 
+  flatMapP<B>(mapper: (a: A) => Promise<B>): Future<B> {
+    return new Future(
+      when.promise(
+        (resolve: (b: B) => void, reject: (error: Error) => void): void => {
+          this.promise
+            .then((value: A): void => {
+              mapper(value)
+                .then((b: B): void => {
+                  resolve(b);
+                })
+                .catch((error: Error) => {
+                  reject(error)
+                })
+            })
+            .catch((error: Error) => {
+              reject(error)
+            })
+        }
+      )
+    );
+  }
+
   foreach<B>(run: (a: A) => B): void {
     this.promise
       .then((value: A): void => {

--- a/test/future/future.ts
+++ b/test/future/future.ts
@@ -30,6 +30,18 @@ test('Future#flatMap', async(t: TestContext) => {
   await t.throws(failure.flatMap(() => success).promise);
 });
 
+test('Future#flatMapP', async(t: TestContext) => {
+  t.plan(3);
+
+  const successfulFlatMap: string = await success.flatMapP(() => Promise.resolve('world')).promise;
+  t.is(successfulFlatMap, 'world');
+
+  const failingFlatMap: when.Promise<void> = success.flatMapP(() => Promise.reject(new Error)).promise;
+  await t.throws(failingFlatMap);
+
+  await t.throws(failure.flatMapP(() => Promise.resolve("hello")).promise);
+});
+
 test('Future#foreach', async(t: TestContext) => {
   t.plan(2);
 


### PR DESCRIPTION
Add Future#flatMapP for continuing a Future chain by returning a Promise instead of another Future. This makes working with async functions inside of futures a little more clean.

I just ended up wanting this while working today and added it in. I'm not sure whether it fits with your vision of what you want the API to look like, but it does make Futures a bit easier to use with async functions, so user doesn't have to wrap any async functions in a `flatMap` with a call to `Future.create`.